### PR TITLE
fix: resolve links with story.full_slug

### DIFF
--- a/src/lib/resolvers/linkResolvers.test.ts
+++ b/src/lib/resolvers/linkResolvers.test.ts
@@ -59,6 +59,19 @@ describe('linkResolvers', () => {
     expect(result?.newTab).toBe(false)
   })
 
+  it('resolves an internal url without `links` in context', () => {
+    const result = resolvers.Article.url(
+      { url: { id: '1', linktype: 'story', anchor: 'test-hash', story: { full_slug: '/article/test-article-story' } } },
+      null,
+      {}
+    )
+    expect(result?.url).toBe('/article/test-article-story#test-hash')
+    expect(result?.hash).toBe('test-hash')
+    expect(result?.pathname).toBe('/article/test-article-story')
+    expect(result?.type).toBe('internal')
+    expect(result?.newTab).toBe(false)
+  })
+
   it('ignores an internal url with `links` in context if the link does not exist', () => {
     const result = resolvers.Article.url(
       { url: { id: '1', linktype: 'story', anchor: 'test-hash' } },

--- a/src/lib/resolvers/linkResolvers.ts
+++ b/src/lib/resolvers/linkResolvers.ts
@@ -122,6 +122,18 @@ export const toStoryblokLink = (
           (link.anchor ? `#${link.anchor}` : ''),
         pathname: urlResolver(fullSlug, context),
       }
+    } else if (context && link.story?.full_slug) {
+      const fullSlug = link.story.full_slug
+
+      return {
+        type: 'internal',
+        hash: link.anchor,
+        newTab: link.target === '_blank', // internal links are not newTab by default
+        url:
+          urlResolver(fullSlug, context) +
+          (link.anchor ? `#${link.anchor}` : ''),
+        pathname: urlResolver(fullSlug, context),
+      }
     }
 
     // if there is no context, we do it through the cached_url


### PR DESCRIPTION
Resolve storyblok links without `resolve_links` but based on story.full_slug. This is way more accurate then internal links.